### PR TITLE
UniswapV2Router CV update

### DIFF
--- a/src/dfktools/dex/uniswap_v2_router.py
+++ b/src/dfktools/dex/uniswap_v2_router.py
@@ -1,11 +1,10 @@
 """
 https://docs.uniswap.org/protocol/V2/reference/smart-contracts/router-02
 """
-
 from web3 import Web3
 
-
-CONTRACT_ADDRESS = '0x24ad62502d1C652Cc7684081169D04896aC20f30'
+SERENDALE_CONTRACT_ADDRESS = '0x24ad62502d1C652Cc7684081169D04896aC20f30'
+CRYSTALVALE_CONTRACT_ADDRESS = '0x3C351E1afdd1b1BC44e931E12D4E05D6125eaeCa'
 
 ABI = """
         [
@@ -41,7 +40,7 @@ def block_explorer_link(txid):
     return 'https://explorer.harmony.one/tx/' + str(txid)
 
 
-def weth(rpc_address):
+def weth(router_contract, rpc_address):
     '''
     Return the wrapped address of the native token of the blockchain
     :param rpc_address:
@@ -50,49 +49,49 @@ def weth(rpc_address):
 
     w3 = Web3(Web3.HTTPProvider(rpc_address))
 
-    contract_address = Web3.toChecksumAddress(CONTRACT_ADDRESS)
+    contract_address = Web3.toChecksumAddress(router_contract)
     contract = w3.eth.contract(contract_address, abi=ABI)
 
     return contract.functions.WETH().call()
 
 
-def factory(rpc_address):
+def factory(router_contract, rpc_address):
     w3 = Web3(Web3.HTTPProvider(rpc_address))
 
-    contract_address = Web3.toChecksumAddress(CONTRACT_ADDRESS)
+    contract_address = Web3.toChecksumAddress(router_contract)
     contract = w3.eth.contract(contract_address, abi=ABI)
 
     return contract.functions.factory().call()
 
 
-def quote(amount_a, reserve_a, reserve_b, rpc_address):
+def quote(router_contract, amount_a, reserve_a, reserve_b, rpc_address):
     w3 = Web3(Web3.HTTPProvider(rpc_address))
 
-    contract_address = Web3.toChecksumAddress(CONTRACT_ADDRESS)
+    contract_address = Web3.toChecksumAddress(router_contract)
     contract = w3.eth.contract(contract_address, abi=ABI)
 
     return contract.functions.quote(amount_a, reserve_a, reserve_b).call()
 
 
-def get_amount_in(amount_out, reserve_in, reserve_out, rpc_address):
+def get_amount_in(router_contract, amount_out, reserve_in, reserve_out, rpc_address):
     w3 = Web3(Web3.HTTPProvider(rpc_address))
 
-    contract_address = Web3.toChecksumAddress(CONTRACT_ADDRESS)
+    contract_address = Web3.toChecksumAddress(router_contract)
     contract = w3.eth.contract(contract_address, abi=ABI)
 
     return contract.functions.getAmountIn(amount_out, reserve_in, reserve_out).call()
 
 
-def get_amount_out(amount_in, reserve_in, reserve_out, rpc_address):
+def get_amount_out(router_contract, amount_in, reserve_in, reserve_out, rpc_address):
     w3 = Web3(Web3.HTTPProvider(rpc_address))
 
-    contract_address = Web3.toChecksumAddress(CONTRACT_ADDRESS)
+    contract_address = Web3.toChecksumAddress(router_contract)
     contract = w3.eth.contract(contract_address, abi=ABI)
 
     return contract.functions.getAmountOut(amount_in, reserve_in, reserve_out).call()
 
 
-def swap_exact_tokens_for_tokens(amount_in, amount_out_min, path, to, deadline, private_key, nonce, gas_price_gwei, tx_timeout_seconds, rpc_address, logger):
+def swap_exact_tokens_for_tokens(router_contract, amount_in, amount_out_min, path, to, deadline, private_key, nonce, gas_price_gwei, tx_timeout_seconds, rpc_address, logger):
     '''
     Swaps an exact amount of input tokens for as many output tokens as possible, along the route determined by the
     path. The first element of path is the input token, the last is the output token, and any intermediate elements
@@ -110,17 +109,20 @@ def swap_exact_tokens_for_tokens(amount_in, amount_out_min, path, to, deadline, 
     :param logger:
     :return:
     '''
-
     w3 = Web3(Web3.HTTPProvider(rpc_address))
     account = w3.eth.account.privateKeyToAccount(private_key)
     w3.eth.default_account = account.address
 
-    contract_address = Web3.toChecksumAddress(CONTRACT_ADDRESS)
+    contract_address = Web3.toChecksumAddress(router_contract)
     contract = w3.eth.contract(contract_address, abi=ABI)
-
-    tx = contract.functions.swapExactTokensForTokens(amount_in, amount_out_min, path, to, deadline).buildTransaction(
-        {'gasPrice': w3.toWei(gas_price_gwei, 'gwei'), 'nonce': nonce})
-
+    if isinstance(gas_price_gwei, dict):
+        tx = contract.functions.swapExactTokensForTokens(amount_in, amount_out_min, path, to, deadline).buildTransaction(
+            {'maxFeePerGas': w3.toWei(gas_price_gwei['maxFeePerGas'], 'gwei'),
+            'maxPriorityFeePerGas': w3.toWei(gas_price_gwei['maxPriorityFeePerGas'], 'gwei'),
+            'nonce': nonce})
+    else: # legacy 
+        tx = contract.functions.swapExactTokensForTokens(amount_in, amount_out_min, path, to, deadline).buildTransaction(
+            {'gasPrice': w3.toWei(gas_price_gwei, 'gwei'), 'nonce': nonce})
     logger.debug("Signing transaction")
     signed_tx = w3.eth.account.sign_transaction(tx, private_key=private_key)
     logger.debug("Sending transaction " + str(tx))
@@ -136,7 +138,7 @@ def swap_exact_tokens_for_tokens(amount_in, amount_out_min, path, to, deadline, 
     return tx_receipt
 
 
-def swap_exact_tokens_for_eth(amount_in, amount_out_min, path, to, deadline, private_key, nonce, gas_price_gwei, tx_timeout_seconds, rpc_address, logger):
+def swap_exact_tokens_for_eth(router_contract, amount_in, amount_out_min, path, to, deadline, private_key, nonce, gas_price_gwei, tx_timeout_seconds, rpc_address, logger):
     '''
     Swaps an exact amount of tokens for as much ETH as possible, along the route determined by the path.
     The first element of path is the input token, the last must be WETH, and any intermediate elements represent
@@ -158,12 +160,17 @@ def swap_exact_tokens_for_eth(amount_in, amount_out_min, path, to, deadline, pri
     account = w3.eth.account.privateKeyToAccount(private_key)
     w3.eth.default_account = account.address
 
-    contract_address = Web3.toChecksumAddress(CONTRACT_ADDRESS)
+    contract_address = Web3.toChecksumAddress(router_contract)
     contract = w3.eth.contract(contract_address, abi=ABI)
 
-    tx = contract.functions.swapExactTokensForETH(amount_in, amount_out_min, path, to, deadline).buildTransaction(
-        {'gasPrice': w3.toWei(gas_price_gwei, 'gwei'), 'nonce': nonce})
-
+    if isinstance(gas_price_gwei, dict):
+        tx = contract.functions.swapExactTokensForETH(amount_in, amount_out_min, path, to, deadline).buildTransaction(
+            {'maxFeePerGas': w3.toWei(gas_price_gwei['maxFeePerGas'], 'gwei'),
+            'maxPriorityFeePerGas': w3.toWei(gas_price_gwei['maxPriorityFeePerGas'], 'gwei'),
+            'nonce': nonce})
+    else: # legacy 
+        tx = contract.functions.swapExactTokensForETH(amount_in, amount_out_min, path, to, deadline).buildTransaction(
+            {'gasPrice': w3.toWei(gas_price_gwei, 'gwei'), 'nonce': nonce})
     logger.debug("Signing transaction")
     signed_tx = w3.eth.account.sign_transaction(tx, private_key=private_key)
     logger.debug("Sending transaction " + str(tx))


### PR DESCRIPTION
Added the UniswapV2Router contract address for Crystalvale. 

Refactored the functions inside in a manner similar to quest_core_v2.py. Each function now takes router_contract as an argument to support both CV and SD calls.

Added dynamic fee support (EIP-1559).